### PR TITLE
Order imports

### DIFF
--- a/cmd/vt/main.go
+++ b/cmd/vt/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mitchellh/go-wordwrap"
 	"github.com/iamleot/go-treccani"
+	"github.com/mitchellh/go-wordwrap"
 )
 
 // PrintDefinition pretty prints a term definition.


### PR DESCRIPTION
`go fmt' should be called against `./...' in order to recursively
format all the files, not just `.'!

No functional change.
