### PR TITLE
Update CI/CD pipeline to Go 1.19.x

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Check formatting
         run: |
           gofmt -l . | awk '{ print } END { exit(NR > 0) }'


### PR DESCRIPTION
Go 1.19 is the latest stable version, let's stick with it.
