### PR TITLE
Add Makefile and use it for CI/CD pipeline

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,13 +16,13 @@ jobs:
           go-version: 1.19
       - name: Check formatting
         run: |
-          gofmt -l . | awk '{ print } END { exit(NR > 0) }'
+          make check-fmt
       - name: Get dependencies
         run: |
-          go get -v -t -d ./...
+          make depends
       - name: Build
         run: |
-          go build -v ./...
+          make build
       - name: Test
         run: |
-          go test -v ./...
+          make check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.POSIX:
+
+AWK = awk
+GO = go
+GOFMT = gofmt
+
+all:
+
+build:
+	@echo "Building vt"
+	@$(GO) build -v ./...
+
+check:
+	@echo "Testing vt"
+	@$(GO) test -v ./...
+
+check-fmt:
+	@echo "Checking formatting"
+	@$(GOFMT) -l . | $(AWK) '{ print } END { exit(NR > 0) }'
+
+depends:
+	@echo "Get dependencies"
+	@$(GO) get -v -t -d ./...
+
+fmt:
+	@echo "Formatting Go files"
+	@$(GO) fmt ./...


### PR DESCRIPTION
`make` is everywhere (unlike GitHub Actions) and can be easily run locally. Adjust GitHub Actions workflow to calls make targets.