### PR TITLE
Switch to Go 1.19 also in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iamleot/go-treccani
 
-go 1.18
+go 1.19
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.1


### PR DESCRIPTION
Accidentally missed as part of commit 64fb3b9575b207911d7f957ab1feda6f30df745f.

Done via `go mod edit -go=1.19`.
