### PR TITLE
Add gosec target and run gosec as part of the CI/CD pipeline

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,6 +3,9 @@ name: Go CI/CD
 on:
   push:
 
+env:
+  GOSEC_VERSION: "2.16.0"
+
 jobs:
   build:
     name: Go CI/CD
@@ -14,9 +17,16 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: '1.20'
+      - name: Install gosec
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -sL "https://github.com/securego/gosec/releases/download/v${GOSEC_VERSION}/gosec_${GOSEC_VERSION}_linux_amd64.tar.gz" | tar xzf - -C "${HOME}/.local/bin" gosec
       - name: Check formatting
         run: |
           make check-fmt
+      - name: Check code via gosec
+        run: |
+          make gosec
       - name: Get dependencies
         run: |
           make depends

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 AWK = awk
 GO = go
 GOFMT = gofmt
+GOSEC = gosec
 
 all:
 
@@ -25,3 +26,7 @@ depends:
 fmt:
 	@echo "Formatting Go files"
 	@$(GO) fmt ./...
+
+gosec:
+	@echo "Checking code via gosec"
+	@$(GOSEC) ./...


### PR DESCRIPTION
Add gosec target in Makefile and run it as part of the CI/CD pipeline.

gosec is a static analysis linter for Go to check possible security issues.

For more information please give a look to: <https://github.com/securego/gosec>.
