### PR TITLE
Switch to go-version-file

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
       - name: Install gosec
         run: |
           mkdir -p "${HOME}/.local/bin"


### PR DESCRIPTION
Use `go-version-file` instead of hardcoding `go-version` in order to honor the version that is present in `go.mod` without requiring to adjust it also in GitHub Actions workflows.
