### PR TITLE
Enable Dependabot for go.mod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Quick checks for GitHub Actions and commit message syntax looks okay-ish.

Enable also for go.mod so that we can delegate dependency bumping mostly to Dependabot.
