### PR TITLE
Adjust references to LookupTerm()/Terms() in logging

### DIFF
--- a/treccani_test.go
+++ b/treccani_test.go
@@ -38,7 +38,7 @@ func TestLookupTerm(t *testing.T) {
 
 			definition := LookupTerm(tc.term, client)
 			if !tc.expectedRegexp.MatchString(definition) {
-				t.Fatalf(`LookupTerm("%s") = %q want match for %#q`, tc.term, definition, tc.expectedRegexp)
+				t.Fatalf(`LookupTerm("%s", ...) = %q want match for %#q`, tc.term, definition, tc.expectedRegexp)
 			}
 		})
 	}
@@ -80,7 +80,7 @@ func TestTerms(t *testing.T) {
 
 			definitions := Terms(tc.term, client)
 			if len(definitions) != tc.expectedNumberOfDefinitions {
-				t.Fatalf(`Terms("%s") should return %d definitions but returned %d definitions`, tc.term, tc.expectedNumberOfDefinitions, len(definitions))
+				t.Fatalf(`Terms("%s", ...) should return %d definitions but returned %d definitions`, tc.term, tc.expectedNumberOfDefinitions, len(definitions))
 			}
 		})
 	}


### PR DESCRIPTION
Accidentally missed as part of commit 90ed4fc819f0045ec37af31a8a35a9d50ad79944.

NFC.
