### PR TITLE
Quote `on` to avoid threaty value

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,6 +1,6 @@
 name: Go CI/CD
 
-on:
+'on':
   push:
 
 env:


### PR DESCRIPTION
GitHub Actions workflow uses `on` but this is actually a truthy value in YAML, an alias for `true`.

Spell it via quote.

Noticed via yamllint.

NFC.
