### PR TITLE
Update to Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iamleot/go-treccani
 
-go 1.20
+go 1.22
 
 require (
 	github.com/PuerkitoBio/goquery v1.9.2


### PR DESCRIPTION
Bump Go minimum version to 1.22 that is the oldest non-EOLed one.

Pointed out by running osv-scanner.
