### PR TITLE
Limit Go CI/CD to PRs and main

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,9 @@ name: Go CI/CD
 
 'on':
   push:
+    branches:
+      - main
+  pull_request:
   schedule:
     - cron: '22 3 * * 3'
 


### PR DESCRIPTION
Consistently limit the events that the GitHub Actions workflow is run like the other GitHub Actions workflows.

(Possible pushes to non-main branches should not trigger this GitHub Actions workflows.)
