### PR TITLE
Update to Go 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/iamleot/go-treccani
 
-go 1.24.0
+go 1.26
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0


### PR DESCRIPTION
Go 1.26.x is the latest stable release.
